### PR TITLE
ci: validación en PR (validate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build:prod


### PR DESCRIPTION
## Summary
- Añade CI en PR: `npm ci`, `lint` y `build:prod`.
- `deploy.yml` sigue desplegando solo en push a `main`.

## Test plan
- [ ] CI verde en este PR

Made with [Cursor](https://cursor.com)